### PR TITLE
Show line-specific error in status bar

### DIFF
--- a/lib/atom-jshint.js
+++ b/lib/atom-jshint.js
@@ -84,13 +84,11 @@ module.exports = AtomJshint = (function(){
       });
       if (lineErrors.length > 0) {
         msg = 'Error: ' + lineErrors[0].reason;
-        atom.workspaceView.statusBar.appendLeft('<span id="jshint-status">' + msg + '</span>');
-        return;
       } else {
         msg = errors.length > 0 ? errors.length + ' JSHint error' + (errors.length>1?'s':'') : '';
       }
+      atom.workspaceView.statusBar.appendLeft('<span id="jshint-status">' + msg + '</span>');
     }
-    atom.workspaceView.statusBar.appendLeft('<span id="jshint-status">' + msg + '</span>');
   };
 
 


### PR DESCRIPTION
This change shows the jshint error for the current line in the status bar, instead of the first error. I also added a handler to update the gutter on scroll, since it looked like that was getting redrawn whenever I scrolled more than a few lines. There's probably a better event to use, but I couldn't find it.

No worries if you're already working on this and don't want to merge. I'm having fun just poking around in Atom.
