### PR TITLE
Added comment line deletion in processing config file

### DIFF
--- a/lib/atom-jshint.js
+++ b/lib/atom-jshint.js
@@ -1,6 +1,7 @@
 var Subscriber, AtomJshint;
 var cp = require('child_process');
 var _ = require('underscore-plus');
+var stripComments = require('./util/strip-comments');
 var JSHINT_Worker = null;
 
 var Subscriber = require('emissary').Subscriber;
@@ -244,7 +245,7 @@ module.exports = AtomJshint = (function(){
           }
           try {
             var configFile = fs.readFileSync(configPath, 'UTF8');
-            var conf = JSON.parse(configFile);
+            var conf = JSON.parse(stripComments(configFile));
             config.message = this.getConfigMessage(conf);
           } catch(e){
             console.error('Error parsing config file', e.message);

--- a/lib/util/strip-comments.js
+++ b/lib/util/strip-comments.js
@@ -1,0 +1,22 @@
+var stripComments = function(configFile) {
+  var lines = [];
+  var line = '';
+  for (var i = 0; i < configFile.length; i++) {
+    var char = configFile[i];
+    line += char;
+    if (char === '\n') {
+      lines.push(line);
+      line = '';
+    }
+  }
+  for (var j = 0; j < lines.length; j++) {
+    var myline = lines[j];
+    var match = myline.match(/\s+\/\/.+\n/);
+    if (match && match[0] === myline) {
+      lines[j] = '';
+    }
+  }
+  return lines.join('\n');
+};
+
+module.exports = stripComments;


### PR DESCRIPTION
Looks kind of ugly, but it works in parsing out comment lines.

Tested using [Ember.js .jshintrc](https://github.com/emberjs/ember.js/blob/master/.jshintrc#L31)

Addresses https://github.com/Joezo/atom-jshint/issues/36
