### PR TITLE
Make lines in the panel clickable

### DIFF
--- a/lib/atom-jshint.js
+++ b/lib/atom-jshint.js
@@ -98,8 +98,21 @@ module.exports = AtomJshint = (function(){
     $('#jshint-status-pane').remove();
     if( !errors || !atom.config.get('atom-jshint.showErrorPanel') ) return;
     var html = $('<div id="jshint-status-pane" class="atom-jshint-pane" style="height:">');
-    errors.forEach(function(error){
-      html.append('Line: ' + error.line + ' Char:' + error.character + ' ' + error.reason);
+    var editorView = atom.workspaceView.getActiveView();
+    function sortByLine(a, b) {
+      if (a.line === b.line) {
+        return a.character - b.character;
+      } else {
+        return a.line - b.line;
+      }
+    }
+    errors.sort(sortByLine).forEach(function(error){
+      var line = $('<span>Line: ' + error.line + ' Char:' + error.character + ' ' + error.reason + '</span>');
+      html.append(line);
+      line.click(function(){
+        var position = [error.line - 1, error.character - 1];
+        editorView.editor.setCursorBufferPosition(position);
+      });
       html.append('<br/>');
     });
     atom.workspaceView.prependToBottom(html);

--- a/stylesheets/atom-jshint.less
+++ b/stylesheets/atom-jshint.less
@@ -18,4 +18,10 @@
   max-height: 80px;
   border-top: 1px solid @tool-panel-border-color;
   padding: 0 12.5px;
+  cursor:pointer;
+
+  span:hover {
+    text-decoration: underline;
+  }
+
 }


### PR DESCRIPTION
Sort errors, by line and character number. Then display them as clickable links that takes you to the error. Also includes touchup to the stylesheet.

Closes #13
