### PR TITLE
Fixed bug with not running on view change. Editor is renamed to TextEdit...

### DIFF
--- a/lib/atom-jshint.js
+++ b/lib/atom-jshint.js
@@ -18,10 +18,10 @@ module.exports = AtomJshint = (function(){
     this.currentConfig = null;
     this.npmConfig = this.loadNpmConfig();
     this.subscribe(atom.workspaceView, 'pane-container:active-pane-item-changed',
-        function(event,editor){
+      function(event,editor){
         this.unsubscribeEditor(this.editor);
         this.currentConfig = null;
-        if (editor && editor.constructor && editor.constructor.name === 'Editor'){
+        if (editor && editor.constructor && editor.constructor.name === 'TextEditor'){
           this.editor = editor;
           this.subscribeEditor(editor);
           this.run(editor);


### PR DESCRIPTION
Seems Atom has renamed the Editor class to TextEditor. This resulted in that the hinting process was not started on view changes anymore. This simple fix should resolve that. But it goes to show that hard coding the constructor name like this might not be the best idea.. 

This might fix #44. Perhaps someone can confirm. This bug only affects hinting on view change, meaning if you have a file already open when you start atom it should hint that file correctly. 
